### PR TITLE
fix(schema): skip parsing path params if its empty

### DIFF
--- a/src/generator/schema.ts
+++ b/src/generator/schema.ts
@@ -31,7 +31,10 @@ export const getParameterObjects = (
   pathParameters: string[],
   headersSchema: AnyZodObject | undefined,
   inType: 'all' | 'path' | 'query',
-): ZodOpenApiParameters | undefined => {
+): ZodOpenApiParameters | undefined => {  
+  if (pathParameters.length === 0)
+    return { header: headersSchema, path: z.object({}), query: z.object({}) };
+
   const shape = schema.shape;
   const shapeKeys = Object.keys(shape);
 


### PR DESCRIPTION
Hey, this is just a one-off I caught while writing some endpoints. Basically, if the getParametersObject is parsing on an endpoint that doesn't have pathParameters, it may throw an exception in unintended scenarios, such as when having an object as a parameter in a request body.

The scenario I'm referring to is something long the lines of this:

```typescript

const helloWorldRouter = router({
  get: endpoint
    .meta({
      openapi: {
        method: 'GET',
        path: '/hello',
      }
    })
    .input(z.object({ sup: z.object({ hi: z.string() }) })) // <--- having "sup" as z.object or z.array causes an exception
    .output(z.void())
    .query(async () => {})
 //...
 ```

Feel free to reject this, as I'm aware that this is a fork of a fork of an unmaintained npm package and the last thing I'd want to do is burden anyone with more work! haha