### PR TITLE
export all internals

### DIFF
--- a/src/adapters/express.ts
+++ b/src/adapters/express.ts
@@ -1,10 +1,7 @@
 import { Request, Response } from 'express';
 
 import { OpenApiRouter } from '../types';
-import {
-  CreateOpenApiNodeHttpHandlerOptions,
-  createOpenApiNodeHttpHandler,
-} from './node-http/core';
+import { CreateOpenApiNodeHttpHandlerOptions, createOpenApiNodeHttpHandler } from './node-http';
 
 export type CreateOpenApiExpressMiddlewareOptions<TRouter extends OpenApiRouter> =
   CreateOpenApiNodeHttpHandlerOptions<TRouter, Request, Response>;

--- a/src/adapters/fastify.ts
+++ b/src/adapters/fastify.ts
@@ -2,10 +2,7 @@ import { AnyRouter } from '@trpc/server';
 import { FastifyInstance } from 'fastify';
 
 import { OpenApiRouter } from '../types';
-import {
-  CreateOpenApiNodeHttpHandlerOptions,
-  createOpenApiNodeHttpHandler,
-} from './node-http/core';
+import { CreateOpenApiNodeHttpHandlerOptions, createOpenApiNodeHttpHandler } from './node-http';
 
 export type CreateOpenApiFastifyPluginOptions<TRouter extends OpenApiRouter> =
   CreateOpenApiNodeHttpHandlerOptions<TRouter, any, any> & {

--- a/src/adapters/fetch.ts
+++ b/src/adapters/fetch.ts
@@ -4,8 +4,8 @@ import { getRequestInfo } from '@trpc/server/unstable-core-do-not-import';
 import { IncomingMessage, ServerResponse } from 'http';
 
 import { OpenApiRouter } from '../types';
-import { normalizePath } from '../utils/path';
-import { createOpenApiNodeHttpHandler } from './node-http/core';
+import { normalizePath } from '../utils';
+import { createOpenApiNodeHttpHandler } from './node-http';
 
 export type CreateOpenApiFetchHandlerOptions<TRouter extends OpenApiRouter> = Omit<
   FetchHandlerOptions<TRouter>,

--- a/src/adapters/index.ts
+++ b/src/adapters/index.ts
@@ -4,3 +4,4 @@ export * from './next';
 export * from './fastify';
 export * from './fetch';
 export * from './nuxt';
+export * from './node-http';

--- a/src/adapters/next.ts
+++ b/src/adapters/next.ts
@@ -3,11 +3,8 @@ import { incomingMessageToRequest } from '@trpc/server/adapters/node-http';
 import { NextApiRequest, NextApiResponse } from 'next';
 
 import { OpenApiErrorResponse, OpenApiRouter } from '../types';
-import { normalizePath } from '../utils/path';
-import {
-  CreateOpenApiNodeHttpHandlerOptions,
-  createOpenApiNodeHttpHandler,
-} from './node-http/core';
+import { normalizePath } from '../utils';
+import { CreateOpenApiNodeHttpHandlerOptions, createOpenApiNodeHttpHandler } from './node-http';
 
 export type CreateOpenApiNextHandlerOptions<TRouter extends OpenApiRouter> =
   CreateOpenApiNodeHttpHandlerOptions<TRouter, NextApiRequest, NextApiResponse>;

--- a/src/adapters/node-http/core.ts
+++ b/src/adapters/node-http/core.ts
@@ -18,16 +18,16 @@ import {
   OpenApiRouter,
   OpenApiSuccessResponse,
 } from '../../types';
-import { acceptsRequestBody } from '../../utils/method';
-import { normalizePath } from '../../utils/path';
-import { getInputOutputParsers } from '../../utils/procedure';
 import {
+  acceptsRequestBody,
+  normalizePath,
+  getInputOutputParsers,
   coerceSchema,
   instanceofZodTypeLikeVoid,
   instanceofZodTypeObject,
   unwrapZodType,
   zodSupportsCoerce,
-} from '../../utils/zod';
+} from '../../utils';
 import { TRPC_ERROR_CODE_HTTP_STATUS, getErrorFromUnknown } from './errors';
 import { getBody, getQuery } from './input';
 import { createProcedureCache } from './procedures';
@@ -205,7 +205,7 @@ export const createOpenApiNodeHttpHandler = <
         ...errorShape, // Pass the error through
         message: isInputValidationError
           ? 'Input validation failed'
-          : (errorShape?.message ?? error.message ?? 'An error occurred'),
+          : errorShape?.message ?? error.message ?? 'An error occurred',
         code: error.code,
         issues: isInputValidationError ? (error.cause as ZodError).errors : undefined,
       };

--- a/src/adapters/node-http/index.ts
+++ b/src/adapters/node-http/index.ts
@@ -1,0 +1,4 @@
+export * from './core';
+export * from './errors';
+export * from './input';
+export * from './procedures';

--- a/src/adapters/node-http/procedures.ts
+++ b/src/adapters/node-http/procedures.ts
@@ -1,6 +1,5 @@
 import { OpenApiMethod, OpenApiProcedure, OpenApiRouter } from '../../types';
-import { getPathRegExp, normalizePath } from '../../utils/path';
-import { forEachOpenApiProcedure } from '../../utils/procedure';
+import { getPathRegExp, normalizePath, forEachOpenApiProcedure } from '../../utils';
 
 export const createProcedureCache = (router: OpenApiRouter) => {
   const procedureCache = new Map<

--- a/src/adapters/nuxt.ts
+++ b/src/adapters/nuxt.ts
@@ -4,11 +4,8 @@ import { defineEventHandler, getQuery } from 'h3';
 import { IncomingMessage } from 'http';
 
 import { OpenApiErrorResponse, OpenApiRouter } from '../types';
-import { normalizePath } from '../utils/path';
-import {
-  CreateOpenApiNodeHttpHandlerOptions,
-  createOpenApiNodeHttpHandler,
-} from './node-http/core';
+import { normalizePath } from '../utils';
+import { CreateOpenApiNodeHttpHandlerOptions, createOpenApiNodeHttpHandler } from './node-http';
 
 export type CreateOpenApiNuxtHandlerOptions<TRouter extends OpenApiRouter> = Omit<
   CreateOpenApiNodeHttpHandlerOptions<TRouter, NodeIncomingMessage, NodeServerResponse>,

--- a/src/generator/paths.ts
+++ b/src/generator/paths.ts
@@ -8,15 +8,17 @@ import {
 } from 'zod-openapi';
 
 import { OpenApiRouter } from '../types';
-import { acceptsRequestBody } from '../utils/method';
-import { getPathParameters, normalizePath } from '../utils/path';
-import { forEachOpenApiProcedure, getInputOutputParsers } from '../utils/procedure';
 import {
+  acceptsRequestBody,
+  getPathParameters,
+  normalizePath,
+  forEachOpenApiProcedure,
+  getInputOutputParsers,
   instanceofZodType,
   instanceofZodTypeLikeVoid,
   instanceofZodTypeObject,
   unwrapZodType,
-} from '../utils/zod';
+} from '../utils';
 import { getParameterObjects, getRequestBodyObject, getResponsesObject, hasInputs } from './schema';
 
 extendZodWithOpenApi(z);

--- a/src/generator/schema.ts
+++ b/src/generator/schema.ts
@@ -13,7 +13,7 @@ import {
   HTTP_STATUS_TRPC_ERROR_CODE,
   TRPC_ERROR_CODE_HTTP_STATUS,
   TRPC_ERROR_CODE_MESSAGE,
-} from '../adapters/node-http/errors';
+} from '../adapters';
 import { OpenApiContentType } from '../types';
 import {
   instanceofZodType,
@@ -24,7 +24,7 @@ import {
   instanceofZodTypeOptional,
   unwrapZodType,
   zodSupportsCoerce,
-} from '../utils/zod';
+} from '../utils';
 import { HttpMethods } from './paths';
 
 extendZodWithOpenApi(z);
@@ -175,7 +175,9 @@ export const errorResponseObject = (
                 }),
             })
             .openapi({
-              title: `${message ?? 'Internal server'} error (${TRPC_ERROR_CODE_HTTP_STATUS[code] ?? 500})`,
+              title: `${message ?? 'Internal server'} error (${
+                TRPC_ERROR_CODE_HTTP_STATUS[code] ?? 500
+              })`,
               description: 'The error information',
               example: {
                 code: code ?? 'INTERNAL_SERVER_ERROR',
@@ -217,9 +219,9 @@ export const getResponsesObject = (
         schema: instanceofZodTypeKind(schema, z.ZodFirstPartyTypeKind.ZodVoid)
           ? {}
           : instanceofZodTypeKind(schema, z.ZodFirstPartyTypeKind.ZodNever) ||
-              instanceofZodTypeKind(schema, z.ZodFirstPartyTypeKind.ZodUndefined)
-            ? { not: {} }
-            : schema,
+            instanceofZodTypeKind(schema, z.ZodFirstPartyTypeKind.ZodUndefined)
+          ? { not: {} }
+          : schema,
       },
     },
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,60 +1,6 @@
-import { OpenApiBuilder } from 'openapi3-ts/oas31';
+export { OpenApiBuilder } from 'openapi3-ts/oas31';
 
-import {
-  CreateOpenApiExpressMiddlewareOptions,
-  CreateOpenApiFastifyPluginOptions,
-  CreateOpenApiFetchHandlerOptions,
-  CreateOpenApiHttpHandlerOptions,
-  CreateOpenApiNextHandlerOptions,
-  CreateOpenApiNuxtHandlerOptions,
-  createOpenApiExpressMiddleware,
-  createOpenApiFetchHandler,
-  createOpenApiHttpHandler,
-  createOpenApiNextHandler,
-  createOpenApiNuxtHandler,
-  fastifyTRPCOpenApiPlugin,
-} from './adapters';
-import { GenerateOpenApiDocumentOptions, generateOpenApiDocument } from './generator';
-import {
-  errorResponseFromMessage,
-  errorResponseFromStatusCode,
-  errorResponseObject,
-} from './generator/schema';
-import {
-  OpenApiErrorResponse,
-  OpenApiMeta,
-  OpenApiMethod,
-  OpenApiResponse,
-  OpenApiRouter,
-  OpenApiSuccessResponse,
-} from './types';
-import { ZodTypeLikeString, ZodTypeLikeVoid } from './utils/zod';
-
-export {
-  CreateOpenApiExpressMiddlewareOptions,
-  CreateOpenApiHttpHandlerOptions,
-  CreateOpenApiNextHandlerOptions,
-  CreateOpenApiFastifyPluginOptions,
-  CreateOpenApiFetchHandlerOptions,
-  CreateOpenApiNuxtHandlerOptions,
-  createOpenApiExpressMiddleware,
-  createOpenApiFetchHandler,
-  createOpenApiHttpHandler,
-  createOpenApiNextHandler,
-  createOpenApiNuxtHandler,
-  fastifyTRPCOpenApiPlugin,
-  generateOpenApiDocument,
-  errorResponseObject,
-  errorResponseFromStatusCode,
-  errorResponseFromMessage,
-  GenerateOpenApiDocumentOptions,
-  OpenApiBuilder,
-  OpenApiRouter,
-  OpenApiMeta,
-  OpenApiMethod,
-  OpenApiResponse,
-  OpenApiSuccessResponse,
-  OpenApiErrorResponse,
-  ZodTypeLikeString,
-  ZodTypeLikeVoid,
-};
+export * from './utils';
+export * from './adapters';
+export * from './types';
+export * from './generator';

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,0 +1,4 @@
+export * from './method';
+export * from './path';
+export * from './procedure';
+export * from './zod';


### PR DESCRIPTION
Reworked the exports so we can expose all internals. Moving from trpc-openapi to this project I painfully noticed that its impossible to import specific files from dist, since this project uses package.json exports. 

This makes it impossible to accesss things like TRPC_ERROR_CODE_HTTP_STATUS,  acceptsRequestBody or exports related to creating a custom adapter.