### PR TITLE
Reversal of change to stop Fastify adapter request decorators being stripped

### DIFF
--- a/src/adapters/fastify.ts
+++ b/src/adapters/fastify.ts
@@ -25,12 +25,9 @@ export function fastifyTRPCOpenApiPlugin<TRouter extends AnyRouter>(
 
   fastify.all(`${prefix}/*`, async (request, reply) => {
     const prefixRemovedFromUrl = request.url.replace(fastify.prefix, '').replace(prefix, '');
-    const rawRequest = Object.assign(request.raw, {
-      body: request.body,
-      url: prefixRemovedFromUrl,
-    });
+    request.raw.url = prefixRemovedFromUrl;
     return await openApiHttpHandler(
-      rawRequest,
+      request,
       Object.assign(reply, {
         once: () => undefined,
         setHeader: (key: string, value: string | number | readonly string[]) => {


### PR DESCRIPTION
In a change made to the fastify adapter during the upgrade to v11, the request object was modified to use `request.raw`. This modification ended up stripping decorators from the request object. If there was a reason for the modification, we can alter the solution to take that into account. For now, it works with trpc v11 as previously defined.

Thanks!