### PR TITLE
fix(fastify): send raw request in http handler

### DIFF
--- a/src/adapters/fastify.ts
+++ b/src/adapters/fastify.ts
@@ -26,21 +26,7 @@ export function fastifyTRPCOpenApiPlugin<TRouter extends AnyRouter>(
   fastify.all(`${prefix}/*`, async (request, reply) => {
     const prefixRemovedFromUrl = request.url.replace(fastify.prefix, '').replace(prefix, '');
     request.raw.url = prefixRemovedFromUrl;
-    return await openApiHttpHandler(
-      request,
-      Object.assign(reply, {
-        once: () => undefined,
-        setHeader: (key: string, value: string | number | readonly string[]) => {
-          if (Array.isArray(value)) {
-            value.forEach((v) => reply.header(key, v));
-            return reply;
-          }
-
-          return reply.header(key, value);
-        },
-        end: (body: any) => reply.send(body),
-      }),
-    );
+    return await openApiHttpHandler(request, reply.raw);
   });
 
   done();


### PR DESCRIPTION
Hello,

We are migrating to tRPC 11 in our project, and therefore migrated from `trpc-openapi` to `trpc-to-openapi`. During this process, I noticed a runtime error when doing a basic request on REST endpoints exposed by the Fastify adapter, and after some investigation it turns out that `off()` method is expected (by tRPC 11) to be found on the `res` itself (see [here](https://github.com/trpc/trpc/blob/f6efa479190996c22bc1e541fdb1ad6a9c06f5b1/packages/server/src/adapters/node-http/incomingMessageToRequest.ts#L129), which is not the case currently.

A basic hello-world using:

- tRPC `^11.0.1` (latest)
- fastify `^5.2.2` (latest)
- trpc-to-openapi `^2.1.4` (latest)

Is causing this error on request:

```
<REDACTED>/node_modules/@trpc/server/dist/adapters/node-http/incomingMessageToRequest.js:94
        res.off('close', onAbort);
            ^

TypeError: res.off is not a function
    at Socket.onAbort (<REDACTED>/node_modules/@trpc/server/dist/adapters/node-http/incomingMessageToRequest.js:94:13)
    at Object.onceWrapper (node:events:622:26)
    at Socket.emit (node:events:519:35)
    at TCP.<anonymous> (node:net:350:12)

Node.js v23.1.0
```

After some digging, turns out that the problem completely disappear by just forwarding `reply.raw` to `openApiHttpHandler`. But I'm not sure of the eventual side-effects that this change can have, I only penny-tested my own case, and checked that it didn't broke any test.

Additional material:

- a 40-lines minimal reproduction example can be found here: https://github.com/meriadec/repro-trpc-to-openapi-fastify-bug
- or directly on Stackblitz here: https://stackblitz.com/edit/stackblitz-starters-gcoccrab?file=index.ts

Hence, proposing this fix.

Let me know if it makes sense for you! Thanks for maintaining the package!