### PR TITLE
fix: meta can be undefined

### DIFF
--- a/src/utils/procedure.ts
+++ b/src/utils/procedure.ts
@@ -47,8 +47,8 @@ export const forEachOpenApiProcedure = <TMeta = Record<string, unknown>>(
 ) => {
   for (const [path, procedure] of Object.entries(procedureRecord)) {
     // @ts-expect-error FIXME
-    const meta = procedure._def.meta as unknown as OpenApiMeta;
-    if (meta.openapi && meta.openapi.enabled !== false) {
+    const meta = procedure._def.meta as unknown as OpenApiMeta | undefined;
+    if (meta?.openapi && meta.openapi.enabled !== false) {
       const type = getProcedureType(procedure as OpenApiProcedure);
       callback({
         path,


### PR DESCRIPTION
Hey I think the last version introduced a regression. The meta flag can be undefined and was previously catched with a fallback empty object:

![image](https://github.com/user-attachments/assets/463e5122-1a3c-4161-b320-371343f2f935)

Noticed it as our renovate update has run the tests and one of them failed with `TypeError: Cannot read properties of undefined (reading 'openapi')`