### PR TITLE
Add API to override default generated operationId

### DIFF
--- a/src/generator/paths.ts
+++ b/src/generator/paths.ts
@@ -58,6 +58,7 @@ export const getOpenApiPathsObject = <TMeta = Record<string, unknown>>(
       const { openapi } = meta;
       const {
         method,
+        operationId,
         summary,
         description,
         tags,
@@ -171,7 +172,7 @@ export const getOpenApiPathsObject = <TMeta = Record<string, unknown>>(
       pathsObject[path] = {
         ...pathsObject[path],
         [httpMethod]: {
-          operationId: procedurePath.replace(/\./g, '-'),
+          operationId: operationId ?? procedurePath.replace(/\./g, '-'),
           summary,
           description,
           tags,

--- a/src/types.ts
+++ b/src/types.ts
@@ -27,6 +27,7 @@ export type OpenApiMeta<TMeta = TRPCMeta> = TMeta & {
     enabled?: boolean;
     method: OpenApiMethod;
     path: `/${string}`;
+    operationId?: string;
     summary?: string;
     description?: string;
     protect?: boolean;

--- a/test/generator.test.ts
+++ b/test/generator.test.ts
@@ -3345,4 +3345,24 @@ describe('generator', () => {
     expect(openApiDocument.paths!['/public']).toBeDefined();
     expect(openApiDocument.paths!['/private']).toBeUndefined();
   });
+
+  test('with custom operationId', () => {
+    const appRouter = t.router({
+      getMe: t.procedure
+        .meta({
+          openapi: {
+            method: 'GET',
+            path: '/metadata/all',
+            operationId: 'getAllMetadataAboutMe',
+          },
+        })
+        .input(z.object({ name: z.string() }))
+        .output(z.object({ name: z.string() }))
+        .query(({ input }) => ({ name: input.name })),
+    });
+
+    const openApiDocument = generateOpenApiDocument(appRouter, defaultDocOpts);
+
+    expect(openApiDocument.paths!['/metadata/all']!.get!.operationId).toBe('getAllMetadataAboutMe');
+  });
 });


### PR DESCRIPTION
This PR introduces the ability to override the automatically generated `operationId` for individual procedures when generating the OpenAPI document.

Previously, the `operationId` was always derived from the procedurePath (with . replaced by -). This change allows developers to define a custom operationId through the procedure’s meta.openapi.operationId field, giving them full control over the identifier used in the OpenAPI specification.