### PR TITLE
Allows passing complex examples to objects

### DIFF
--- a/src/generator/paths.ts
+++ b/src/generator/paths.ts
@@ -1,5 +1,4 @@
 import { TRPCError } from '@trpc/server';
-import { z } from 'zod';
 import {
   ZodOpenApiParameters,
   ZodOpenApiPathsObject,
@@ -111,12 +110,11 @@ export const getOpenApiPathsObject = <TMeta = Record<string, unknown>>(
       const isInputRequired = !inputParser.safeParse(undefined).success;
 
       const o = inputParser.meta();
-
       const inputSchema = unwrapZodType(inputParser, true).meta({
         ...(o?.title ? { title: o?.title } : {}),
         ...(o?.description ? { description: o?.description } : {}),
+        ...(o?.examples ? { examples: o?.examples } : {}),
       });
-
       const requestData: {
         requestBody?: ZodOpenApiRequestBodyObject;
         requestParams?: ZodOpenApiParameters;

--- a/src/generator/schema.ts
+++ b/src/generator/schema.ts
@@ -139,8 +139,8 @@ export const getRequestBodyObject = (
   const dedupedSchema = schema.omit(mask).meta({
     ...(o?.title ? { title: o?.title } : {}),
     ...(o?.description ? { description: o?.description } : {}),
+    ...(o?.examples ? { examples: o?.examples } : {}),
   });
-
   // if all keys are path parameters
   if (pathParameters.length > 0 && Object.keys(dedupedSchema.shape).length === 0) {
     return undefined;
@@ -236,8 +236,8 @@ export const getResponsesObject = (
         schema: instanceofZodTypeKind(schema, 'void')
           ? {}
           : instanceofZodTypeKind(schema, 'never') || instanceofZodTypeKind(schema, 'undefined')
-          ? { not: {} }
-          : schema,
+            ? { not: {} }
+            : schema,
       },
     },
   },

--- a/test/generator.test.ts
+++ b/test/generator.test.ts
@@ -3116,10 +3116,54 @@ describe('generator', () => {
         .mutation(({ input }) => ({
           output: `${input.greeting} ${input.name}`,
         })),
+      multipleExamples: t.procedure
+        .meta({
+          openapi: {
+            method: 'POST',
+            path: '/multiple-examples',
+          },
+        })
+        .input(
+          z
+            .object({ name: z.string() })
+            .meta({ examples: { Lily: { name: 'Lily' }, John: { name: 'John' } } }),
+        )
+        .output(z.object({ output: z.string() }))
+        .mutation(({ input }) => ({
+          output: `${input.name}`,
+        })),
     });
 
     const openApiDocument = generateOpenApiDocument(appRouter, defaultDocOpts);
 
+    expect(openApiDocument.paths!['/multiple-examples']!.post!.requestBody).toMatchInlineSnapshot(`
+      Object {
+        "content": Object {
+          "application/json": Object {
+            "schema": Object {
+              "examples": Object {
+                "John": Object {
+                  "name": "John",
+                },
+                "Lily": Object {
+                  "name": "Lily",
+                },
+              },
+              "properties": Object {
+                "name": Object {
+                  "type": "string",
+                },
+              },
+              "required": Array [
+                "name",
+              ],
+              "type": "object",
+            },
+          },
+        },
+        "required": true,
+      }
+    `);
     expect(openApiDocument.paths!['/query-example/{name}']!.get!.parameters).toMatchInlineSnapshot(`
       Array [
         Object {


### PR DESCRIPTION
I have some rather complex input types for which I wanted to give multiple examples. I noticed that only one could be given with the current setup.

This PR enables multiple named examples 