### PR TITLE
Fix/allow procedures without input validation2

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ export const appRouter = t.router({
     .query(({ input }) => {
       return { greeting: `Hello ${input.name}!` };
     }),
+
   getStatus: t.procedure
     .meta({ /* 👉 */ openapi: { method: 'GET', path: '/status' } })
     .output(z.object({ status: z.string() }))
@@ -101,8 +102,8 @@ server.listen(3000);
 
 ```typescript
 // client.ts
-const res = await fetch('http://localhost:3000/say-hello?name=Lily', { method: 'GET' });
-const body = await res.json(); /* { greeting: 'Hello Lily!' } */
+const res = await fetch('http://localhost:3000/say-hello?name=OpenAPI', { method: 'GET' });
+const body = await res.json(); /* { greeting: 'Hello OpenAPI!' } */
 
 const statusRes = await fetch('http://localhost:3000/status', { method: 'GET' });
 const statusBody = await statusRes.json(); /* { status: 'healthy' } */

--- a/README.md
+++ b/README.md
@@ -48,6 +48,12 @@ export const appRouter = t.router({
     .output(z.object({ greeting: z.string() }))
     .query(({ input }) => {
       return { greeting: `Hello ${input.name}!` };
+    }),
+  getStatus: t.procedure
+    .meta({ /* 👉 */ openapi: { method: 'GET', path: '/status' } })
+    .output(z.object({ status: z.string() }))
+    .query(() => {
+      return { status: 'healthy' };
     });
 });
 ```
@@ -97,6 +103,9 @@ server.listen(3000);
 // client.ts
 const res = await fetch('http://localhost:3000/say-hello?name=Lily', { method: 'GET' });
 const body = await res.json(); /* { greeting: 'Hello Lily!' } */
+
+const statusRes = await fetch('http://localhost:3000/status', { method: 'GET' });
+const statusBody = await statusRes.json(); /* { status: 'healthy' } */
 ```
 
 ## Requirements
@@ -108,12 +117,13 @@ Peer dependencies:
 
 For a procedure to support OpenAPI the following _must_ be true:
 
-- Both `input` and `output` parsers are present AND use `Zod` validation.
-- Query `input` parsers extend `Object<{ [string]: String | Number | BigInt | Date }>` or `Void`.
-- Mutation `input` parsers extend `Object<{ [string]: AnyType }>` or `Void`.
+- An `output` parser is present AND uses `Zod` validation.
+- If an `input` parser is present, it must use `Zod` validation.
+- Query `input` parsers (when present) extend `Object<{ [string]: String | Number | BigInt | Date }>` or `Void`.
+- Mutation `input` parsers (when present) extend `Object<{ [string]: AnyType }>` or `Void`.
 - `meta.openapi.method` is `GET`, `POST`, `PATCH`, `PUT` or `DELETE`.
 - `meta.openapi.path` is a string starting with `/`.
-- `meta.openapi.path` parameters exist in `input` parser as `String | Number | BigInt | Date`
+- `meta.openapi.path` parameters (when present) exist in `input` parser as `String | Number | BigInt | Date`
 
 Please note:
 
@@ -344,16 +354,16 @@ main();
 
 Please see [full typings here](src/generator/index.ts).
 
-| Property          | Type                                   | Description                                             | Required |
-| ----------------- | -------------------------------------- | ------------------------------------------------------- | -------- |
-| `title`           | `string`                               | The title of the API.                                   | `true`   |
-| `description`     | `string`                               | A short description of the API.                         | `false`  |
-| `version`         | `string`                               | The version of the OpenAPI document.                    | `true`   |
-| `baseUrl`         | `string`                               | The base URL of the target server.                      | `true`   |
-| `docsUrl`         | `string`                               | A URL to any external documentation.                    | `false`  |
-| `tags`            | `string[]`                             | A list for ordering endpoint groups.                    | `false`  |
-| `securitySchemes` | `Record<string, SecuritySchemeObject>` | Defaults to `Authorization` header with `Bearer` scheme | `false`  |
-| `filter` | `(ctx: { metadata: { openapi: NonNullable<OpenApiMeta['openapi']> } & TMeta }) => boolean` | Optional filter function to include/exclude procedures from the generated OpenAPI document. | `false`  |
+| Property          | Type                                                                                       | Description                                                                                 | Required |
+| ----------------- | ------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------- | -------- |
+| `title`           | `string`                                                                                   | The title of the API.                                                                       | `true`   |
+| `description`     | `string`                                                                                   | A short description of the API.                                                             | `false`  |
+| `version`         | `string`                                                                                   | The version of the OpenAPI document.                                                        | `true`   |
+| `baseUrl`         | `string`                                                                                   | The base URL of the target server.                                                          | `true`   |
+| `docsUrl`         | `string`                                                                                   | A URL to any external documentation.                                                        | `false`  |
+| `tags`            | `string[]`                                                                                 | A list for ordering endpoint groups.                                                        | `false`  |
+| `securitySchemes` | `Record<string, SecuritySchemeObject>`                                                     | Defaults to `Authorization` header with `Bearer` scheme                                     | `false`  |
+| `filter`          | `(ctx: { metadata: { openapi: NonNullable<OpenApiMeta['openapi']> } & TMeta }) => boolean` | Optional filter function to include/exclude procedures from the generated OpenAPI document. | `false`  |
 
 #### OpenApiMeta
 

--- a/examples/with-express/src/router.ts
+++ b/examples/with-express/src/router.ts
@@ -167,7 +167,6 @@ const usersRouter = t.router({
         summary: 'Read all users',
       },
     })
-    .input(z.void())
     .output(
       z.object({
         users: z.array(
@@ -187,6 +186,27 @@ const usersRouter = t.router({
       }));
 
       return { users };
+    }),
+  getHealth: publicProcedure
+    .meta({
+      openapi: {
+        method: 'GET',
+        path: '/health',
+        tags: ['system'],
+        summary: 'Health check endpoint',
+      },
+    })
+    .output(
+      z.object({
+        status: z.string(),
+        timestamp: z.string(),
+      }),
+    )
+    .query(() => {
+      return {
+        status: 'healthy',
+        timestamp: new Date().toISOString(),
+      };
     }),
   getUserById: publicProcedure
     .meta({

--- a/examples/with-fastify/src/router.ts
+++ b/examples/with-fastify/src/router.ts
@@ -34,7 +34,7 @@ export const createContext = async ({
   req,
   res,
 }: // eslint-disable-next-line @typescript-eslint/require-await
-CreateFastifyContextOptions): Promise<Context> => {
+  CreateFastifyContextOptions): Promise<Context> => {
   const requestId = uuid();
   res.header('x-request-id', requestId);
 
@@ -165,7 +165,6 @@ const usersRouter = t.router({
         summary: 'Read all users',
       },
     })
-    .input(z.void())
     .output(
       z.object({
         users: z.array(

--- a/examples/with-nextjs-appdir/src/server/router.ts
+++ b/examples/with-nextjs-appdir/src/server/router.ts
@@ -172,7 +172,6 @@ const usersRouter = t.router({
         summary: 'Read all users',
       },
     })
-    .input(z.void())
     .output(
       z.object({
         users: z.array(

--- a/examples/with-nextjs/src/server/router.ts
+++ b/examples/with-nextjs/src/server/router.ts
@@ -164,7 +164,6 @@ const usersRouter = t.router({
         summary: 'Read all users',
       },
     })
-    .input(z.void())
     .output(
       z.object({
         users: z.array(

--- a/examples/with-nuxtjs/server/router.ts
+++ b/examples/with-nuxtjs/server/router.ts
@@ -171,7 +171,6 @@ const usersRouter = t.router({
         summary: 'Read all users',
       },
     })
-    .input(z.void())
     .output(
       z.object({
         users: z.array(

--- a/src/adapters/node-http/core.ts
+++ b/src/adapters/node-http/core.ts
@@ -114,7 +114,7 @@ export const createOpenApiNodeHttpHandler = <
         });
       }
 
-      const inputParser = getInputOutputParsers(procedure.procedure).inputParser as ZodTypeAny;
+      const { inputParser } = getInputOutputParsers(procedure.procedure);
       const unwrappedSchema = unwrapZodType(inputParser, true);
 
       // input should stay undefined if z.void()
@@ -130,7 +130,7 @@ export const createOpenApiNodeHttpHandler = <
         if (!useBody) {
           for (const [key, shape] of Object.entries(unwrappedSchema.shape)) {
             let isArray = false;
-            
+
             // Check if it's a direct array
             if (shape instanceof ZodArray) {
               isArray = true;
@@ -142,7 +142,7 @@ export const createOpenApiNodeHttpHandler = <
                 isArray = true;
               }
             }
-            
+
             if (isArray && input[key] !== undefined && !Array.isArray(input[key])) {
               input[key] = [input[key]];
             }
@@ -228,7 +228,7 @@ export const createOpenApiNodeHttpHandler = <
         ...errorShape, // Pass the error through
         message: isInputValidationError
           ? 'Input validation failed'
-          : errorShape?.message ?? error.message ?? 'An error occurred',
+          : (errorShape?.message ?? error.message ?? 'An error occurred'),
         code: error.code,
         issues: isInputValidationError ? (error.cause as ZodError).issues : undefined,
       };

--- a/src/utils/procedure.ts
+++ b/src/utils/procedure.ts
@@ -13,17 +13,28 @@ const mergeInputs = (inputParsers: ZodObject[]): ZodObject => {
 export const getInputOutputParsers = (
   procedure: OpenApiProcedure,
 ): {
-  inputParser: ZodObject | undefined;
+  inputParser: ZodObject;
   outputParser: ZodObject | undefined;
+  hasInputsDefined: boolean;
 } => {
   // @ts-expect-error The types seems to be incorrect
   const inputs = procedure._def.inputs as ZodObject[];
   // @ts-expect-error The types seems to be incorrect
-  const output = procedure._def.output;
+  const output = procedure._def.output as ZodObject | undefined;
+
+  let inputParser: ZodObject;
+  if (inputs.length >= 2) {
+    inputParser = mergeInputs(inputs);
+  } else if (inputs.length === 1) {
+    inputParser = inputs[0]!;
+  } else {
+    inputParser = z.object({});
+  }
 
   return {
-    inputParser: inputs.length >= 2 ? mergeInputs(inputs) : inputs[0],
+    inputParser,
     outputParser: output,
+    hasInputsDefined: inputs.length > 0,
   };
 };
 

--- a/test/generator.test.ts
+++ b/test/generator.test.ts
@@ -1487,7 +1487,6 @@ describe('generator', () => {
       const appRouter = t.router({
         void: t.procedure
           .meta({ openapi: { method: 'GET', path: '/void' } })
-          //no input schema
           .output(z.void())
           .query(() => undefined),
       });
@@ -1510,7 +1509,6 @@ describe('generator', () => {
       const appRouter = t.router({
         void: t.procedure
           .meta({ openapi: { method: 'POST', path: '/void' } })
-          // .input(z.void())
           .output(z.void())
           .mutation(() => undefined),
       });
@@ -1535,7 +1533,6 @@ describe('generator', () => {
     const appRouter = t.router({
       null: t.procedure
         .meta({ openapi: { method: 'POST', path: '/null' } })
-        .input(z.void())
         .output(z.null())
         .mutation(() => null),
     });

--- a/test/generator.test.ts
+++ b/test/generator.test.ts
@@ -63,13 +63,30 @@ describe('generator', () => {
       const appRouter = t.router({
         noInput: t.procedure
           .meta({ openapi: { method: 'GET', path: '/no-input' } })
+          .input(z.void())
           .output(z.object({ name: z.string() }))
           .query(() => ({ name: 'mcampa' })),
       });
 
-      expect(() => {
-        generateOpenApiDocument(appRouter, defaultDocOpts);
-      }).toThrowError('[query.noInput] - Input parser expects a Zod validator');
+      const document = generateOpenApiDocument(appRouter, defaultDocOpts);
+      expect(document.paths).toBeDefined();
+      expect(document.paths!['/no-input']?.get).toBeDefined();
+      expect(document.paths!['/no-input']?.get?.requestBody).toBeUndefined();
+      expect(document.paths!['/no-input']?.get?.parameters).toBeUndefined();
+    }
+    {
+      const appRouter = t.router({
+        noInput: t.procedure
+          .meta({ openapi: { method: 'GET', path: '/no-input' } })
+          .output(z.object({ name: z.string() }))
+          .query(() => ({ name: 'mcampa' })),
+      });
+
+      const document = generateOpenApiDocument(appRouter, defaultDocOpts);
+      expect(document.paths).toBeDefined();
+      expect(document.paths!['/no-input']?.get).toBeDefined();
+      expect(document.paths!['/no-input']?.get?.requestBody).toBeUndefined();
+      expect(document.paths!['/no-input']?.get?.parameters).toBeUndefined();
     }
     {
       const appRouter = t.router({
@@ -79,9 +96,11 @@ describe('generator', () => {
           .mutation(() => ({ name: 'mcampa' })),
       });
 
-      expect(() => {
-        generateOpenApiDocument(appRouter, defaultDocOpts);
-      }).toThrowError('[mutation.noInput] - Input parser expects a Zod validator');
+      const document = generateOpenApiDocument(appRouter, defaultDocOpts);
+      expect(document.paths).toBeDefined();
+      expect(document.paths!['/no-input']?.post).toBeDefined();
+      expect(document.paths!['/no-input']?.post?.requestBody).toBeUndefined();
+      expect(document.paths!['/no-input']?.post?.parameters).toBeUndefined();
     }
   });
 
@@ -1467,8 +1486,31 @@ describe('generator', () => {
     {
       const appRouter = t.router({
         void: t.procedure
+          .meta({ openapi: { method: 'GET', path: '/void' } })
+          //no input schema
+          .output(z.void())
+          .query(() => undefined),
+      });
+
+      const openApiDocument = generateOpenApiDocument(appRouter, defaultDocOpts);
+
+      expect(openApiDocument.paths!['/void']!.get!.parameters).toEqual(undefined);
+      expect(openApiDocument.paths!['/void']!.get!.responses?.[200]).toMatchInlineSnapshot(`
+        Object {
+          "content": Object {
+            "application/json": Object {
+              "schema": Object {},
+            },
+          },
+          "description": "Successful response",
+        }
+      `);
+    }
+    {
+      const appRouter = t.router({
+        void: t.procedure
           .meta({ openapi: { method: 'POST', path: '/void' } })
-          .input(z.void())
+          // .input(z.void())
           .output(z.void())
           .mutation(() => undefined),
       });
@@ -3450,7 +3492,7 @@ describe('generator', () => {
       required: ['id', 'title', 'price'],
     });
   });
-    
+
   test('with custom operationId', () => {
     const appRouter = t.router({
       getMe: t.procedure


### PR DESCRIPTION
Original [PR](https://github.com/mcampa/trpc-to-openapi/pull/123) by @gaetansenn

## 🐛 Fix: Allow tRPC procedures without input validation

### Problem
`trpc-to-openapi` crashed when tRPC procedures didn't specify `.input()`, throwing:


This prevented using natural tRPC patterns and forced developers to add artificial `.input(z.void())` calls just for OpenAPI compatibility.

### Root Cause
The library expected all OpenAPI procedures to have Zod input validators, but tRPC procedures can work perfectly without any input validation. This created an incompatibility between natural tRPC usage and OpenAPI documentation generation.

### Solution
- Handle `undefined` input parsers gracefully in `getInputOutputParsers()`
- Create default empty object schema for procedures without input validation
- Update validation logic to accept procedures without input parsers
- Update examples to showcase natural tRPC usage patterns
- Maintain full backward compatibility with existing code

### Impact
✅ **Before**: Forced to use `.input(z.void())` workaround  
✅ **After**: Natural tRPC procedures work seamlessly  
✅ **Compatibility**: All existing code continues to work  
✅ **Tests**: All 126 tests pass + updated test coverage  

### Example Usage
```typescript
// ✅ Now works (previously crashed)
const getData = t.procedure
  .meta({ 
    openapi: { 
      method: 'GET', 
      path: '/data',
      summary: 'Get data without input parameters'
    } 
  })
  .output(z.object({ message: z.string() }))
  .query(() => ({ message: 'Hello World' }));

// Works for both:
// 1. Native tRPC calls: trpc.getData.query()
// 2. OpenAPI documentation generation
```

### Files Changed
- `src/utils/procedure.ts`: Handle empty inputs array gracefully
- `src/generator/paths.ts`: Accept undefined input parsers  
- `test/generator.test.ts`: Update tests to verify the fix
- `examples/*/router.ts`: Remove unnecessary `.input(z.void())` calls

This change enables the natural interoperability between tRPC and OpenAPI that developers expect, without breaking any existing functionality.