### PR TITLE
Fix: update zod-openapi to 5.4.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "ts-node": "^10.9.1",
     "typescript": "5.8.3",
     "zod": "^4.0.0",
-    "zod-openapi": "5.4.2"
+    "zod-openapi": "5.4.5"
   },
   "optionalDependencies": {
     "@rollup/rollup-linux-x64-gnu": "4.6.1"


### PR DESCRIPTION
Upgrade zod-openapi library 

Cannot convert undefined or null to object
apps/middleware dev:       at Function.entries (<anonymous>)
apps/middleware dev:       at override (file:///Users/gaetansenn/Development/aromazone/middleware/node_modules/.pnpm/zod-openapi@5.4.3_zod@4.1.13/node_modules/zod-openapi/dist/components-DV_-zLJ6.js:206:39)
apps/middleware dev:       at JSONSchemaGenerator.override (file:///Users/gaetansenn/Development/aromazone/middleware/node_modules/.pnpm/zod-openapi@5.4.3_zod@4.1.13/node_modules/zod-openapi/dist/components-DV_-zLJ6.js:372:4)