### PR TITLE
fix: Zod 4 compatibility for prefault, transform pipes, and refined schema omit

### DIFF
--- a/src/generator/schema.ts
+++ b/src/generator/schema.ts
@@ -136,7 +136,21 @@ export const getRequestBodyObject = (
     mask[pathParameter] = true;
   });
   const o = schema.meta();
-  const dedupedSchema = schema.omit(mask).meta({
+  // Use omit() when possible, fall back to manual shape filtering for refined schemas
+  let dedupedSchema;
+  try {
+    dedupedSchema = schema.omit(mask);
+  } catch {
+    // Zod 4 throws on .omit() for schemas with refinements - rebuild from shape
+    const filteredShape: Record<string, z.ZodType> = {};
+    for (const [key, value] of Object.entries(schema.shape)) {
+      if (!mask[key]) {
+        filteredShape[key] = value as z.ZodType;
+      }
+    }
+    dedupedSchema = z.object(filteredShape);
+  }
+  dedupedSchema = dedupedSchema.meta({
     ...(o?.title ? { title: o?.title } : {}),
     ...(o?.description ? { description: o?.description } : {}),
     ...(o?.examples ? { examples: o?.examples } : {}),

--- a/src/utils/zod.ts
+++ b/src/utils/zod.ts
@@ -49,10 +49,18 @@ export const unwrapZodType = (type: $ZodType, unwrapPreprocess: boolean): ZodTyp
   if (instanceofZodTypeKind(type, 'default')) {
     return unwrapZodType((type as z.ZodDefault<$ZodTypes>).unwrap(), unwrapPreprocess);
   }
+  if (instanceofZodTypeKind(type, 'prefault')) {
+    return unwrapZodType((type as z.ZodDefault<$ZodTypes>).unwrap(), unwrapPreprocess);
+  }
   if (instanceofZodTypeKind(type, 'lazy')) {
     return unwrapZodType((type as z.ZodLazy<$ZodTypes>).def.getter(), unwrapPreprocess);
   }
   if (instanceofZodTypeKind(type, 'pipe') && unwrapPreprocess) {
+    // For .transform() pipes in Zod 4, def.out is a 'transform' type -
+    // use def.in (the input schema shape) instead
+    if (instanceofZodTypeKind((type as z.ZodPipe<$ZodTypes>)._zod.def.out, 'transform')) {
+      return unwrapZodType((type as z.ZodPipe<$ZodTypes>)._zod.def.in, unwrapPreprocess);
+    }
     return unwrapZodType((type as z.ZodPipe<$ZodTypes>).def.out, unwrapPreprocess);
   }
   return type as ZodType;


### PR DESCRIPTION
## Summary

Fixes compatibility issues when using trpc-to-openapi with Zod 4:

- **`prefault` type support**: Zod 4 introduces a `prefault` type (similar to `default`). Added handling in `unwrapZodType` to unwrap it via `.unwrap()`, matching the existing `default` behavior.
- **`.transform()` pipe handling**: In Zod 4, `.transform().superRefine()` creates a `pipe` where `def.out` is an opaque `transform` type rather than a usable schema. When this is detected, the unwrapper now follows `def.in` (the input schema shape) instead.
- **Refined schema `.omit()` fallback**: Zod 4 throws when calling `.omit()` on object schemas that have refinements. Wrapped the `.omit()` call in `getRequestBodyObject` with a try/catch that falls back to manually filtering path parameter keys from `schema.shape`.

Fixes https://github.com/mcampa/trpc-to-openapi/issues/153

## Test plan

- [ ] Verify `unwrapZodType` correctly unwraps `z.prefault()` schemas
- [ ] Verify `unwrapZodType` follows `def.in` for pipes where `def.out` is a transform
- [ ] Verify `getRequestBodyObject` works with refined object schemas that have path parameters
- [ ] Verify existing behavior is unchanged for non-Zod-4 usage patterns