### PR TITLE
feat: add contact and license to GenerateOpenApiDocumentOptions

### DIFF
--- a/src/generator/index.ts
+++ b/src/generator/index.ts
@@ -9,10 +9,24 @@ import {
 } from '../types';
 import { getOpenApiPathsObject, mergePaths } from './paths';
 
+export interface OpenApiContactObject {
+  name?: string;
+  url?: string;
+  email?: string;
+}
+
+export interface OpenApiLicenseObject {
+  name: string;
+  identifier?: string;
+  url?: string;
+}
+
 export interface GenerateOpenApiDocumentOptions<TMeta = Record<string, unknown>> {
   title: string;
   description?: string;
   version: string;
+  contact?: OpenApiContactObject;
+  license?: OpenApiLicenseObject;
   openApiVersion?: ZodOpenApiObject['openapi'];
   baseUrl: string;
   docsUrl?: string;
@@ -58,6 +72,8 @@ export const generateOpenApiDocument = <TMeta = Record<string, unknown>>(
       title: opts.title,
       description: opts.description,
       version: opts.version,
+      ...(opts.contact && { contact: opts.contact }),
+      ...(opts.license && { license: opts.license }),
     },
     servers: [
       {


### PR DESCRIPTION
## Summary

Resolves #156.

Extends `GenerateOpenApiDocumentOptions` with optional `contact` and `license` fields that map 1:1 to the OpenAPI 3.x `info` sub-objects:

```ts
generateOpenApiDocument(appRouter, {
  title: 'My API',
  version: '1.0.0',
  baseUrl: 'https://api.example.com',
  contact: { name: 'Engineering', email: 'team@example.com', url: 'https://example.com' },
  license: { name: 'Apache-2.0' },
});
```

## Changes

- Added `OpenApiContactObject` and `OpenApiLicenseObject` interfaces (exported)
- Added `contact?` and `license?` fields to `GenerateOpenApiDocumentOptions`
- Passes them through to the `info` block in `generateOpenApiDocument` when provided
- No breaking changes — both fields are optional

## Why

Redocly and other OpenAPI linters warn when `info.contact` is absent (`info-contact` rule). Previously the only workaround was post-mutating the returned document, which pushes metadata that naturally belongs in the options object into imperative code.