### PR TITLE
fix: add OpenAPI extension index signature to contact/license types

### DIFF
--- a/src/generator/index.ts
+++ b/src/generator/index.ts
@@ -10,12 +10,14 @@ import {
 import { getOpenApiPathsObject, mergePaths } from './paths';
 
 export interface OpenApiContactObject {
+  [key: `x-${string}`]: any;
   name?: string;
   url?: string;
   email?: string;
 }
 
 export interface OpenApiLicenseObject {
+  [key: `x-${string}`]: any;
   name: string;
   identifier?: string;
   url?: string;


### PR DESCRIPTION
## Summary

Master CI has been failing since #157 with:

\`\`\`
src/generator/index.ts(71,5): error TS2322:
  Type '{ license?: OpenApiLicenseObject | undefined; contact?: OpenApiContactObject | undefined; ... }'
    is not assignable to type 'InfoObject'.
  ...
  Index signature for type \`x-\${string}\` is missing in type 'OpenApiContactObject'.
\`\`\`

\`zod-openapi\`'s \`ContactObject\` and \`LicenseObject\` require an \`[key: \`x-\${string}\`]: any\` index signature for OpenAPI extension fields. The local \`OpenApiContactObject\` and \`OpenApiLicenseObject\` interfaces introduced in #157 didn't include it, so \`opts.contact\` / \`opts.license\` couldn't be assigned to the \`info\` field at \`src/generator/index.ts:71\`.

Added the missing index signature to both interfaces.

## Test plan

- [x] \`pnpm exec tsc --noEmit\` passes (2.2s, no errors)
- [x] \`pnpm exec jest\` — 129/129 tests passing across all 8 suites
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)