### PR TITLE
fix: bump zod-openapi to 5.4.6 with discriminated-union regression test (supersedes #151)

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "peerDependencies": {
     "@trpc/server": "^11.1.0",
     "zod": "^3.25.0 || ^4.0.0",
-    "zod-openapi": "^5.0.1"
+    "zod-openapi": "^5.4.4"
   },
   "dependencies": {
     "co-body": "6.2.0",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "ts-jest": "^29.1.0",
     "ts-node": "^10.9.1",
     "typescript": "5.8.3",
-    "zod": "^4.0.0",
+    "zod": "4.1.13",
     "zod-openapi": "5.4.2"
   },
   "optionalDependencies": {

--- a/package.json
+++ b/package.json
@@ -75,8 +75,8 @@
     "ts-jest": "^29.1.0",
     "ts-node": "^10.9.1",
     "typescript": "5.8.3",
-    "zod": "4.1.13",
-    "zod-openapi": "5.4.2"
+    "zod": "^4.1.13",
+    "zod-openapi": "5.4.6"
   },
   "optionalDependencies": {
     "@rollup/rollup-linux-x64-gnu": "4.6.1"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -100,11 +100,11 @@ importers:
         specifier: 5.8.3
         version: 5.8.3
       zod:
-        specifier: 4.1.13
+        specifier: ^4.1.13
         version: 4.1.13
       zod-openapi:
-        specifier: 5.4.2
-        version: 5.4.2(zod@4.1.13)
+        specifier: 5.4.6
+        version: 5.4.6(zod@4.1.13)
     optionalDependencies:
       '@rollup/rollup-linux-x64-gnu':
         specifier: 4.6.1
@@ -6171,6 +6171,12 @@ packages:
 
   zod-openapi@5.4.2:
     resolution: {integrity: sha512-F2s/1E/8Ahd43JhrkqE/dc13qjaGF/VTdUVq7rtRKvyDWyuYYryyzdxHnzH1ff1zLpd4KkvNvIpeBnVQShlxYg==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      zod: ^3.25.74 || ^4.0.0
+
+  zod-openapi@5.4.6:
+    resolution: {integrity: sha512-P2jsOOBAq/6hCwUsMCjUATZ8szkMsV5VAwZENfyxp2Hc/XPJQpVwAgevWZc65xZauCwWB9LAn7zYeiCJFAEL+A==}
     engines: {node: '>=20'}
     peerDependencies:
       zod: ^3.25.74 || ^4.0.0
@@ -12972,7 +12978,7 @@ snapshots:
     dependencies:
       zod: 4.0.14
 
-  zod-openapi@5.4.2(zod@4.1.13):
+  zod-openapi@5.4.6(zod@4.1.13):
     dependencies:
       zod: 4.1.13
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -100,11 +100,11 @@ importers:
         specifier: 5.8.3
         version: 5.8.3
       zod:
-        specifier: ^4.0.0
-        version: 4.0.14
+        specifier: 4.1.13
+        version: 4.1.13
       zod-openapi:
         specifier: 5.4.2
-        version: 5.4.2(zod@4.0.14)
+        version: 5.4.2(zod@4.1.13)
     optionalDependencies:
       '@rollup/rollup-linux-x64-gnu':
         specifier: 4.6.1
@@ -6177,6 +6177,9 @@ packages:
 
   zod@4.0.14:
     resolution: {integrity: sha512-nGFJTnJN6cM2v9kXL+SOBq3AtjQby3Mv5ySGFof5UGRHrRioSJ5iG680cYNjE/yWk671nROcpPj4hAS8nyLhSw==}
+
+  zod@4.1.13:
+    resolution: {integrity: sha512-AvvthqfqrAhNH9dnfmrfKzX5upOdjUVJYFqNSlkmGf64gRaTzlPwz99IHYnVs28qYAybvAlBV+H7pn0saFY4Ig==}
 
 snapshots:
 
@@ -12969,4 +12972,10 @@ snapshots:
     dependencies:
       zod: 4.0.14
 
+  zod-openapi@5.4.2(zod@4.1.13):
+    dependencies:
+      zod: 4.1.13
+
   zod@4.0.14: {}
+
+  zod@4.1.13: {}

--- a/test/generator.test.ts
+++ b/test/generator.test.ts
@@ -3514,4 +3514,27 @@ describe('generator', () => {
 
     expect(openApiDocument.paths!['/metadata/all']!.get!.operationId).toBe('getAllMetadataAboutMe');
   });
+
+  // Repro for https://github.com/mcampa/trpc-to-openapi/pull/151
+  // Zod 4.1.13+ emits discriminated unions as `anyOf` rather than `oneOf`,
+  // and zod-openapi <5.4.4 crashes on Object.entries(jsonSchema.oneOf) when
+  // generating the document.
+  test('discriminated union in input does not crash document generation', () => {
+    const appRouter = t.router({
+      submit: t.procedure
+        .meta({ openapi: { method: 'POST', path: '/submit' } })
+        .input(
+          z.object({
+            payload: z.discriminatedUnion('kind', [
+              z.object({ kind: z.literal('a'), a: z.string() }),
+              z.object({ kind: z.literal('b'), b: z.number() }),
+            ]),
+          }),
+        )
+        .output(z.object({ ok: z.boolean() }))
+        .mutation(() => ({ ok: true })),
+    });
+
+    expect(() => generateOpenApiDocument(appRouter, defaultDocOpts)).not.toThrow();
+  });
 });

--- a/test/generator.test.ts
+++ b/test/generator.test.ts
@@ -1253,7 +1253,7 @@ describe('generator', () => {
                   "id": Object {
                     "description": "User ID",
                     "format": "uuid",
-                    "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+                    "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$",
                     "type": "string",
                   },
                   "name": Object {
@@ -1282,7 +1282,7 @@ describe('generator', () => {
                     "id": Object {
                       "description": "User ID",
                       "format": "uuid",
-                      "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+                      "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$",
                       "type": "string",
                     },
                     "name": Object {
@@ -1363,7 +1363,7 @@ describe('generator', () => {
             "schema": Object {
               "description": "User ID",
               "format": "uuid",
-              "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+              "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$",
               "type": "string",
             },
           },
@@ -1379,7 +1379,7 @@ describe('generator', () => {
                     "id": Object {
                       "description": "User ID",
                       "format": "uuid",
-                      "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+                      "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$",
                       "type": "string",
                     },
                     "name": Object {


### PR DESCRIPTION
Supersedes #151 by adding a regression test alongside the version bump.

## Background

zod 4.1.13 [changed how discriminated unions are serialized to JSON Schema](https://github.com/colinhacks/zod/commit/9fc493f86f17a5fc550df78e7e261137885f51ea) — they now emit \`anyOf\` instead of \`oneOf\`. zod-openapi 5.4.0–5.4.3 still expected \`oneOf\` in its schema-override path, so calling \`generateOpenApiDocument\` on any router with a discriminated union input would crash:

\`\`\`
TypeError: Cannot convert undefined or null to object
    at Function.entries (<anonymous>)
    at override (zod-openapi/dist/components-…cjs:231:39)
    at JSONSchemaGenerator.override (…:398:4)
\`\`\`

zod-openapi 5.4.4 fixed this ([samchungy/zod-openapi#556](https://github.com/samchungy/zod-openapi/pull/556)). 5.4.5 added type-declaration fixes. 5.4.6 addresses additional Zod 4.3+ \"cannot be represented in OpenAPI\" compatibility issues.

## Changes

1. **\`test: reproduce zod-openapi discriminated union crash from #151\`** — pins zod to a version where the bug manifests and adds a test that fails on master.
2. **\`fix: bump zod-openapi to 5.4.6\`** — resolves the failing test. Also relaxes the zod devDep pin to \`^4.1.13\` so the regression test keeps exercising the previously-broken code path while allowing minor upgrades.

Two snapshots were regenerated because zod 4.1.x's \`z.string().uuid()\` regex now accepts the max UUID (\`ffffffff-ffff-ffff-ffff-ffffffffffff\`) — pure upstream change, no behavior shift in this package.

## Test plan

- [x] Reproducer commit alone (zod-openapi 5.4.2 + zod 4.1.13): test fails with the exact stack trace from #151
- [x] Fix commit applied: \`pnpm exec jest\` — 130/130 tests passing
- [x] \`pnpm run build\` succeeds (tsc + jest + cjs + esm)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)