### PR TITLE
chore: release version 3.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 ## Changelog
 
+- v3.3.0
+
+  - feat: add `contact` and `license` fields to `GenerateOpenApiDocumentOptions` [#157](https://github.com/mcampa/trpc-to-openapi/pull/157) by [@liorp](https://github.com/liorp)
+  - feat: support zod v3 (≥3.25) alongside v4 via the `zod/v4` permalink import; widens the `zod` peer dep to `^3.25.0 || ^4.0.0` [#161](https://github.com/mcampa/trpc-to-openapi/pull/161) (supersedes [#158](https://github.com/mcampa/trpc-to-openapi/pull/158) by [@Sam152](https://github.com/Sam152))
+  - fix: bump `zod-openapi` to 5.4.6 and raise its peer dep minimum to `^5.4.4` to avoid the discriminated-union crash on zod ≥4.1.13 [#162](https://github.com/mcampa/trpc-to-openapi/pull/162) (supersedes [#151](https://github.com/mcampa/trpc-to-openapi/pull/151) by [@gaetansenn](https://github.com/gaetansenn))
+  - fix: add OpenAPI extension index signature to contact/license types so they satisfy `zod-openapi`'s `InfoObject` [#160](https://github.com/mcampa/trpc-to-openapi/pull/160)
+  - chore: bump `h3` to `^1.15.5` [#159](https://github.com/mcampa/trpc-to-openapi/pull/159) by [@cpimhoff](https://github.com/cpimhoff)
+
 - v3.2.0
 
   - fix: Zod 4 compatibility for `prefault`, transform pipes, and refined-schema `.omit()` [#155](https://github.com/mcampa/trpc-to-openapi/pull/155) by [@MendyLanda](https://github.com/MendyLanda) (fixes [#153](https://github.com/mcampa/trpc-to-openapi/issues/153))

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trpc-to-openapi",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "description": "tRPC OpenAPI",
   "author": "mcampa",
   "private": false,


### PR DESCRIPTION
Cuts the v3.3.0 release. Merging this triggers the NPM Publish workflow.

## What's in this release

- **feat:** \`contact\` and \`license\` fields on \`GenerateOpenApiDocumentOptions\` — #157 by @liorp
- **feat:** support zod v3 (≥3.25) alongside v4 via the \`zod/v4\` permalink import; widens the \`zod\` peer dep to \`^3.25.0 || ^4.0.0\` — #161 (supersedes #158 by @Sam152)
- **fix:** bump \`zod-openapi\` to 5.4.6 and raise its peer dep minimum to \`^5.4.4\` to prevent the discriminated-union crash on zod ≥4.1.13 — #162 (supersedes #151 by @gaetansenn)
- **fix:** add \`x-\${string}\` extension index signature to \`OpenApiContactObject\`/\`OpenApiLicenseObject\` so they satisfy \`zod-openapi\`'s \`InfoObject\` — #160
- **chore:** bump \`h3\` to \`^1.15.5\` — #159 by @cpimhoff

## Why minor and not major

\`zod-openapi\` peer dep tightening (\`^5.0.1\` → \`^5.4.4\`, #162) is technically a restriction, but versions 5.4.0–5.4.3 were already broken for any consumer on zod ≥4.1.13 — this is a guardrail, not a real break.

\`zod\` peer dep widening (\`^4.0.0\` → \`^3.25.0 || ^4.0.0\`, #161) is additive.

## Test plan

- [x] \`pnpm run build\` (tsc + jest + cjs + esm): 130/130 tests passing
- [x] CHANGELOG.md updated with PR links and contributor credits
- [ ] CI green
- [ ] NPM publish workflow on merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)