### PR TITLE
ci: gate npm publish on Node.js CI success

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,19 +1,29 @@
 name: NPM Publish
 
 on:
-  push:
+  workflow_run:
+    workflows: ["Node.js CI"]
+    types:
+      - completed
     branches:
       - master
 
 jobs:
   publish:
     runs-on: ubuntu-latest
+    # Only publish if the CI workflow that triggered us actually succeeded.
+    # workflow_run fires on completion regardless of conclusion.
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}
+      group: ${{ github.workflow }}-${{ github.event.workflow_run.head_sha }}
       cancel-in-progress: true
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          # Check out the exact commit that CI ran against, not just master HEAD
+          # (master may have moved on if another push landed concurrently).
+          ref: ${{ github.event.workflow_run.head_sha }}
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4


### PR DESCRIPTION
## Summary

Switches the \`NPM Publish\` workflow trigger from a direct \`push\` to \`workflow_run\` so it only runs after \`Node.js CI\` completes successfully on master.

### Why

Today both workflows are triggered independently by \`push: branches: [master]\`, with no \`needs:\` relationship. They race in parallel — if \`Node.js CI\` happens to be slower than \`NPM Publish\` (which is common, since publish runs only a subset of tests via \`pnpm run build\`), a broken release can go live before CI flags the issue.

### What changed

- \`on:\` switched from \`push\` to \`workflow_run\` listening for \`Node.js CI\` completion on master
- Added \`if: \${{ github.event.workflow_run.conclusion == 'success' }}\` so we don't publish when CI failed (workflow_run fires on all completion states)
- Pinned \`actions/checkout\` to \`github.event.workflow_run.head_sha\` — without this, the publish job checks out master HEAD at trigger time, which could differ from the SHA that actually passed CI if concurrent pushes landed
- Concurrency group keyed off \`head_sha\` instead of \`github.ref\` for the same reason

### Caveat about workflow_run

\`workflow_run\` triggers always use the workflow file from the **default branch**, not the branch under test. This means the new behavior won't take effect until this PR is merged. Verification will have to happen on the next release after merge.

## Test plan

- [x] YAML parses (workflow shows up in the Actions UI on push)
- [ ] After merge: next push to master triggers \`Node.js CI\`, then \`NPM Publish\` runs only after CI green
- [ ] Manually verify that a CI failure now blocks publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)