### PR TITLE
feat: add Hono adapter (createOpenApiHonoHandler)

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,6 +351,30 @@ async function main() {
 main();
 ```
 
+#### With Hono
+
+Mount the OpenAPI routes as [Hono](https://hono.dev) middleware. `createContext` receives the Hono `Context` as its second argument, so you can read `c.env`, headers, etc.
+
+```typescript
+import { Hono } from 'hono';
+import { createOpenApiHonoHandler } from 'trpc-to-openapi';
+
+import { appRouter } from './router';
+
+const app = new Hono();
+
+app.use(
+  '/api/*',
+  createOpenApiHonoHandler({
+    router: appRouter,
+    endpoint: '/api',
+    createContext: (_opts, c) => ({ authorization: c.req.header('Authorization') }),
+  }),
+);
+
+export default app;
+```
+
 ## Types
 
 #### GenerateOpenApiDocumentOptions

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "express": "^4.18.2",
     "fastify": "^5.1.0",
     "formatter-for-jest-snapshots": "npm:prettier@^2",
+    "hono": "^4.12.23",
     "jest": "^29.5.0",
     "koa": "^2.15.3",
     "next": "^15.3.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -63,6 +63,9 @@ importers:
       formatter-for-jest-snapshots:
         specifier: npm:prettier@^2
         version: prettier@2.8.8
+      hono:
+        specifier: ^4.12.23
+        version: 4.12.23
       jest:
         specifier: ^29.5.0
         version: 29.7.0(@types/node@22.18.8)(ts-node@10.9.2(@types/node@22.18.8)(typescript@5.8.3))
@@ -2150,6 +2153,7 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@unhead/vue@2.0.17':
     resolution: {integrity: sha512-jzmGZYeMAhETV6qfetmLbZzUjjx1TjdNvFSobeFZb73D7dwD9wl/nOAx36qq+TvjZsLJdF5PQWToz2oDGAUqCg==}
@@ -3505,6 +3509,10 @@ packages:
 
   highlightjs-vue@1.0.0:
     resolution: {integrity: sha512-PDEfEF102G23vHmPhLyPboFCD+BkMGu+GuJe2d9/eH4FsCwvgBpnc9n0pGE+ffKdph38s6foEZiEjdgHdzp+IA==}
+
+  hono@4.12.23:
+    resolution: {integrity: sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA==}
+    engines: {node: '>=16.9.0'}
 
   hookable@5.5.3:
     resolution: {integrity: sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==}
@@ -9893,6 +9901,8 @@ snapshots:
   highlight.js@10.7.3: {}
 
   highlightjs-vue@1.0.0: {}
+
+  hono@4.12.23: {}
 
   hookable@5.5.3: {}
 

--- a/src/adapters/hono.ts
+++ b/src/adapters/hono.ts
@@ -1,0 +1,35 @@
+import type { FetchCreateContextFnOptions, FetchCreateContextFn } from '@trpc/server/adapters/fetch';
+import type { Context } from 'hono';
+
+import { OpenApiRouter } from '../types';
+import {
+  CreateOpenApiFetchHandlerOptions,
+  createOpenApiFetchHandler,
+} from './fetch';
+
+export type CreateOpenApiHonoHandlerOptions<TRouter extends OpenApiRouter> = Omit<
+  CreateOpenApiFetchHandlerOptions<TRouter>,
+  'req' | 'endpoint' | 'createContext'
+> & {
+  endpoint?: `/${string}`;
+  createContext?: (
+    opts: FetchCreateContextFnOptions,
+    c: Context,
+  ) => ReturnType<FetchCreateContextFn<TRouter>>;
+};
+
+export const createOpenApiHonoHandler = <TRouter extends OpenApiRouter>(
+  opts: CreateOpenApiHonoHandlerOptions<TRouter>,
+) => {
+  const { createContext, endpoint, ...rest } = opts;
+
+  return (c: Context): Promise<Response> =>
+    createOpenApiFetchHandler({
+      ...rest,
+      req: c.req.raw,
+      endpoint: endpoint ?? '/',
+      createContext: createContext
+        ? (fetchOpts) => createContext(fetchOpts, c)
+        : undefined,
+    } as CreateOpenApiFetchHandlerOptions<TRouter>);
+};

--- a/src/adapters/index.ts
+++ b/src/adapters/index.ts
@@ -3,6 +3,7 @@ export * from './express';
 export * from './next';
 export * from './fastify';
 export * from './fetch';
+export * from './hono';
 export * from './nuxt';
 export * from './node-http';
 export * from './koa';

--- a/test/adapters/hono.test.ts
+++ b/test/adapters/hono.test.ts
@@ -53,4 +53,30 @@ describe('hono adapter', () => {
     expect(res.status).toBe(200);
     expect(await res.json()).toEqual({ payload: 'hi' });
   });
+
+  test('createContext receives the Hono Context as second arg', async () => {
+    const appRouter = t.router({
+      whoami: t.procedure
+        .meta({ openapi: { method: 'GET', path: '/whoami' } })
+        .input(z.void())
+        .output(z.object({ token: z.string() }))
+        .query(({ ctx }) => ({ token: (ctx as { token: string }).token })),
+    });
+
+    const app = new Hono();
+    const createContext = jest.fn((_opts: unknown, c: Context) => ({
+      token: c.req.header('Authorization') ?? 'anon',
+    }));
+    app.use('/*', createOpenApiHonoHandler({ router: appRouter, endpoint: '/', createContext }));
+
+    const res = await app.request('/whoami', {
+      method: 'GET',
+      headers: { Authorization: 'Bearer abc123' },
+    });
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ token: 'Bearer abc123' });
+    expect(createContext).toHaveBeenCalledTimes(1);
+    expect(typeof createContext.mock.calls[0]![1].req.header).toBe('function');
+  });
 });

--- a/test/adapters/hono.test.ts
+++ b/test/adapters/hono.test.ts
@@ -33,4 +33,24 @@ describe('hono adapter', () => {
     expect(res.status).toBe(200);
     expect(await res.json()).toEqual({ greeting: 'Hello Lily!' });
   });
+
+  test('with valid POST mutation (JSON body)', async () => {
+    const appRouter = t.router({
+      echo: t.procedure
+        .meta({ openapi: { method: 'POST', path: '/echo' } })
+        .input(z.object({ payload: z.string() }))
+        .output(z.object({ payload: z.string() }))
+        .mutation(({ input }) => ({ payload: input.payload })),
+    });
+
+    const app = createApp(appRouter, '/');
+    const res = await app.request('/echo', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ payload: 'hi' }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ payload: 'hi' });
+  });
 });

--- a/test/adapters/hono.test.ts
+++ b/test/adapters/hono.test.ts
@@ -79,4 +79,20 @@ describe('hono adapter', () => {
     expect(createContext).toHaveBeenCalledTimes(1);
     expect(typeof createContext.mock.calls[0]![1].req.header).toBe('function');
   });
+
+  test('strips the endpoint prefix when mounted under a sub-path', async () => {
+    const appRouter = t.router({
+      sayHello: t.procedure
+        .meta({ openapi: { method: 'GET', path: '/say-hello' } })
+        .input(z.object({ name: z.string() }))
+        .output(z.object({ greeting: z.string() }))
+        .query(({ input }) => ({ greeting: `Hello ${input.name}!` })),
+    });
+
+    const app = createApp(appRouter, '/api');
+    const res = await app.request('/api/say-hello?name=Sam', { method: 'GET' });
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ greeting: 'Hello Sam!' });
+  });
 });

--- a/test/adapters/hono.test.ts
+++ b/test/adapters/hono.test.ts
@@ -1,0 +1,36 @@
+import { initTRPC } from '@trpc/server';
+import { Hono } from 'hono';
+import type { Context } from 'hono';
+import { z } from 'zod/v4';
+
+import {
+  OpenApiMeta,
+  OpenApiRouter,
+  createOpenApiHonoHandler,
+} from '../../src';
+
+const t = initTRPC.meta<OpenApiMeta>().context().create();
+
+const createApp = (router: OpenApiRouter, endpoint: `/${string}`) => {
+  const app = new Hono();
+  app.use(`${endpoint === '/' ? '' : endpoint}/*`, createOpenApiHonoHandler({ router, endpoint }));
+  return app;
+};
+
+describe('hono adapter', () => {
+  test('with valid GET query', async () => {
+    const appRouter = t.router({
+      sayHello: t.procedure
+        .meta({ openapi: { method: 'GET', path: '/say-hello' } })
+        .input(z.object({ name: z.string() }))
+        .output(z.object({ greeting: z.string() }))
+        .query(({ input }) => ({ greeting: `Hello ${input.name}!` })),
+    });
+
+    const app = createApp(appRouter, '/');
+    const res = await app.request('/say-hello?name=Lily', { method: 'GET' });
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ greeting: 'Hello Lily!' });
+  });
+});

--- a/test/adapters/hono.test.ts
+++ b/test/adapters/hono.test.ts
@@ -95,4 +95,25 @@ describe('hono adapter', () => {
     expect(res.status).toBe(200);
     expect(await res.json()).toEqual({ greeting: 'Hello Sam!' });
   });
+
+  test('returns 404 OpenApiErrorResponse for unmatched route', async () => {
+    const appRouter = t.router({
+      ping: t.procedure
+        .meta({ openapi: { method: 'POST', path: '/ping' } })
+        .input(z.void())
+        .output(z.literal('pong'))
+        .mutation(() => 'pong' as const),
+    });
+
+    const app = createApp(appRouter, '/');
+    const res = await app.request('/does-not-exist', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+    });
+
+    expect(res.status).toBe(404);
+    expect(await res.json()).toEqual(
+      expect.objectContaining({ message: 'Not found', code: 'NOT_FOUND' }),
+    );
+  });
 });


### PR DESCRIPTION
closes #147


## Summary

Adds support for serving the library's OpenAPI-style REST routes on a [Hono](https://hono.dev) app, mirroring how [`@hono/trpc-server`](https://www.npmjs.com/package/@hono/trpc-server) mounts the standard tRPC RPC endpoint.

`createOpenApiHonoHandler` is a thin wrapper over the existing fetch adapter (`createOpenApiFetchHandler`). Since Hono runs on the Web Fetch API, the middleware pulls the native `Request` from `c.req.raw`, injects the Hono `Context` as the second argument to `createContext` (matching `@hono/trpc-server` ergonomics), and delegates to the fetch handler. `endpoint` defaults to `/`.

```ts
import { Hono } from 'hono';
import { createOpenApiHonoHandler } from 'trpc-to-openapi';

const app = new Hono();
app.use(
  '/api/*',
  createOpenApiHonoHandler({
    router: appRouter,
    endpoint: '/api',
    createContext: (_opts, c) => ({ authorization: c.req.header('Authorization') }),
  }),
);
```

## Changes

- **New** `src/adapters/hono.ts` — `createOpenApiHonoHandler` + `CreateOpenApiHonoHandlerOptions`.
- Exported from `src/adapters/index.ts`.
- `hono` added as a **devDependency** only (matches how express/koa/fastify/next are declared).
- **New** `test/adapters/hono.test.ts` — 5 tests: GET query, POST mutation (JSON body), `createContext` receiving the Hono `Context`, endpoint prefix stripping, and 404 error path. Driven by Hono's built-in `app.request(...)`.
- README documents the adapter in the Examples section.

## Testing

- `npm test` → `tsc --noEmit` clean + **135/135 tests pass** (9 suites, including the new `hono adapter` suite).
- Lint: 0 errors, 1 `no-unsafe-return` warning on the `createContext` cast — consistent with the existing ~35-warning `no-unsafe-*` baseline across the other adapters.

## Notes

- `createContext` types reuse the canonical `FetchCreateContextFnOptions` / `FetchCreateContextFn` from `@trpc/server/adapters/fetch` (the same module the fetch adapter imports from), since tRPC wraps `createContext` in `PartialIf` and it isn't directly indexable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)